### PR TITLE
chore(config): Update tsconfig.node.json

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,13 +1,12 @@
 {
   "compilerOptions": {
     "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "noEmit": true
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
# tsconfig.node.jsonの更新
## 変更内容
- tsBuildInfoFileオプションを削除
- noEmitオプションを削除
- types配列に"node"を追加
- その他の設定は維持

## 変更理由：
- ビルド設定の最適化
- Node.js関連の型定義の明示的な含有
- 不要なオプションの削除によるシンプル化

## 影響：
- Vite設定ファイル（vite.config.ts）のTypeScript解析に影響
- Node.js関連の型チェックが改善される可能性あり