### PR TITLE
refac: Consolidate type definitions and introduce utility functions

### DIFF
--- a/src/components/organisms/PopulationGraph.test.tsx
+++ b/src/components/organisms/PopulationGraph.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PopulationGraph from './PopulationGraph';
+import { PrefecturePopulation } from '../../types';
 
 // Rechartsのモックを作成
 jest.mock('recharts', () => {
@@ -19,7 +20,7 @@ jest.mock('recharts', () => {
   };
 });
 
-const mockData = [
+const mockData: PrefecturePopulation[] = [
   {
     prefName: '北海道',
     data: [
@@ -49,7 +50,69 @@ test('renders population graph', async () => {
     { timeout: 5000 }
   );
 
-  // テキストコンテンツの確認は省略（モックの関係で実際のテキストは表示されない）
-
   console.log('Test completed successfully');
 }, 20000);
+
+test('displays "No data available" when no data is provided', () => {
+  render(<PopulationGraph data={[]} />);
+  expect(screen.getByText('No data available')).toBeInTheDocument();
+});
+
+test('renders graph with multiple prefectures', async () => {
+  const multiPrefData: PrefecturePopulation[] = [
+    {
+      prefName: '北海道',
+      data: [
+        { year: 1960, value: 5039206 },
+        { year: 1965, value: 5171800 },
+      ],
+    },
+    {
+      prefName: '東京都',
+      data: [
+        { year: 1960, value: 9683802 },
+        { year: 1965, value: 10869244 },
+      ],
+    },
+  ];
+
+  render(<PopulationGraph data={multiPrefData} />);
+
+  // グラフコンテナの存在を確認
+  const graphContainer = await screen.findByTestId('population-graph');
+  expect(graphContainer).toBeInTheDocument();
+
+  // SVG要素の存在を確認
+  const svg = await screen.findByRole('img');
+  expect(svg).toBeInTheDocument();
+
+  // 注意: 実際のLineコンポーネントの存在は確認できませんが、
+  // データが正しく渡されていることを確認するためのログを追加
+  console.log('Rendered PopulationGraph with data:', multiPrefData);
+});
+
+test('handles data with missing years gracefully', async () => {
+  const irregularData: PrefecturePopulation[] = [
+    {
+      prefName: '沖縄県',
+      data: [
+        { year: 1960, value: 883122 },
+        // 1965年のデータが欠落
+        { year: 1970, value: 945111 },
+      ],
+    },
+  ];
+
+  render(<PopulationGraph data={irregularData} />);
+
+  // グラフコンテナの存在を確認
+  const graphContainer = await screen.findByTestId('population-graph');
+  expect(graphContainer).toBeInTheDocument();
+
+  // SVG要素の存在を確認
+  const svg = await screen.findByRole('img');
+  expect(svg).toBeInTheDocument();
+
+  // データが正しく渡されていることを確認するためのログを追加
+  console.log('Rendered PopulationGraph with irregular data:', irregularData);
+});

--- a/src/components/organisms/PopulationGraph.tsx
+++ b/src/components/organisms/PopulationGraph.tsx
@@ -10,25 +10,17 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
-interface DataPoint {
-  year: number;
-  value: number;
-}
-
-interface PrefectureData {
-  prefName: string;
-  data: DataPoint[];
-}
+import { PrefecturePopulation } from '../../types';
 
 interface PopulationGraphProps {
-  data: PrefectureData[];
+  data: PrefecturePopulation[];
 }
 
 const PopulationGraph: React.FC<PopulationGraphProps> = ({ data }) => {
   console.log('Rendering PopulationGraph with data:', data);
 
   if (!data || data.length === 0) {
-    return <div>データがありません</div>;
+    return <div>No data available</div>;
   }
 
   // 全都道府県のデータを1つの配列にマージ

--- a/src/components/organisms/PrefectureSelector.test..tsx
+++ b/src/components/organisms/PrefectureSelector.test..tsx
@@ -1,7 +1,8 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 import PrefectureSelector from './PrefectureSelector';
+import { Prefecture } from '../../types';
 
-const mockPrefectures = [
+const mockPrefectures: Prefecture[] = [
   { prefCode: 1, prefName: '北海道' },
   { prefCode: 2, prefName: '青森県' },
 ];

--- a/src/components/organisms/PrefectureSelector.tsx
+++ b/src/components/organisms/PrefectureSelector.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import CheckboxWithLabel from '../molecules/CheckboxWithLabel';
+import { Prefecture } from '../../types';
 import styles from './PrefectureSelector.module.css';
 
 interface PrefectureSelectorProps {
-  prefectures: { prefCode: number; prefName: string }[];
-  selectedPrefectures: { [key: number]: boolean };
+  prefectures: Prefecture[];
+  selectedPrefectures: Record<number, boolean>;
   onPrefectureChange: (prefCode: number, checked: boolean) => void;
 }
 

--- a/src/hooks/usePrefectureData.ts
+++ b/src/hooks/usePrefectureData.ts
@@ -1,20 +1,7 @@
 import { useState, useEffect } from 'react';
 import { fetchPrefectures, fetchPopulation } from '../services/api';
-
-interface Prefecture {
-  prefCode: number;
-  prefName: string;
-}
-
-interface PopulationData {
-  year: number;
-  value: number;
-}
-
-interface PrefecturePopulation {
-  prefName: string;
-  data: PopulationData[];
-}
+import { Prefecture, PrefecturePopulation } from '../types';
+import { formatPopulationData } from '../utils/dataProcessing';
 
 export const usePrefectureData = () => {
   const [prefectures, setPrefectures] = useState<Prefecture[]>([]);
@@ -40,7 +27,8 @@ export const usePrefectureData = () => {
       try {
         const data = await fetchPopulation(prefCode);
         const prefName = prefectures.find((pref) => pref.prefCode === prefCode)?.prefName || '';
-        setPopulationData((prev) => [...prev, { prefName, data: data[0].data }]);
+        const formattedData = formatPopulationData(data[0].data);
+        setPopulationData((prev) => [...prev, { prefName, data: formattedData }]);
       } catch (error) {
         console.error('Failed to fetch population data:', error);
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,14 @@
+export interface Prefecture {
+    prefCode: number;
+    prefName: string;
+  }
+  
+  export interface PopulationData {
+    year: number;
+    value: number;
+  }
+  
+  export interface PrefecturePopulation {
+    prefName: string;
+    data: PopulationData[];
+  }

--- a/src/utils/dataProcessing.ts
+++ b/src/utils/dataProcessing.ts
@@ -1,0 +1,9 @@
+import { PopulationData } from '../types';
+
+export const formatPopulationData = (data: PopulationData[]): PopulationData[] => {
+  // データフォーマットのロジックを実装
+  return data.map(item => ({
+    year: item.year,
+    value: Math.round(item.value)
+  }));
+};


### PR DESCRIPTION
## 修正内容

- 共通の型定義を `types/index.ts` に集約
- データ処理用のユーティリティ関数を `utils/dataProcessing.ts` に追加
- 既存のコンポーネントとフックを新しい型定義とユーティリティ関数を使用するように更新
- テストコードを新しい構造に合わせて更新

これらの変更により、コードの一貫性と再利用性が向上し、将来の拡張がより容易になる